### PR TITLE
Add injected environment capabilities to deploy scripts

### DIFF
--- a/deploycontainer.sh
+++ b/deploycontainer.sh
@@ -248,9 +248,15 @@ deploy_container() {
         fi
         BIND_PARMS="--bind ${BIND_TO}"
     fi
+    # check for injected environment vars to pass to `ice run`:
+    # any environment variables beginning with "INJECT_" will be passed to the container as --env
+    INJECTED_ENV=()
+    while read line; do
+        INJECTED_ENV+=("--env ${line#INJECT_}")
+    done < <( env | grep "^INJECT_" )
     # run the container and check the results
     echo "run the container: ice run --name ${MY_CONTAINER_NAME} ${PUBLISH_PORT} ${MEMORY} ${OPTIONAL_ARGS} ${BIND_PARMS} ${IMAGE_NAME} "
-    ice run --name ${MY_CONTAINER_NAME} ${PUBLISH_PORT} ${MEMORY} ${OPTIONAL_ARGS} ${BIND_PARMS} ${IMAGE_NAME} 2> /dev/null
+    ice run --name ${MY_CONTAINER_NAME} ${PUBLISH_PORT} ${MEMORY} ${OPTIONAL_ARGS} ${BIND_PARMS} ${INJECTED_ENV[*]} ${IMAGE_NAME} 2> /dev/null
     local RESULT=$?
     if [ $RESULT -ne 0 ]; then
         echo -e "${red}Failed to deploy ${MY_CONTAINER_NAME} using ${IMAGE_NAME}${no_color}"

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -226,9 +226,15 @@ deploy_group() {
         fi
         BIND_PARMS="--bind ${BIND_TO}"
     fi
+    # check for injected environment vars to pass to `ice run`:
+    # any environment variables beginning with "INJECT_" will be passed to the container as --env
+    INJECTED_ENV=()
+    while read line; do
+        INJECTED_ENV+=("--env ${line#INJECT_}")
+    done < <( env | grep "^INJECT_" )
     # create the group and check the results
     echo "creating group: ice group create --name ${MY_GROUP_NAME} ${BIND_PARMS} ${PUBLISH_PORT} ${MEMORY} ${OPTIONAL_ARGS} --desired ${DESIRED_INSTANCES} ${AUTO} ${IMAGE_NAME}"
-    ice group create --name ${MY_GROUP_NAME} ${BIND_PARMS} ${PUBLISH_PORT} ${MEMORY} ${OPTIONAL_ARGS} --desired ${DESIRED_INSTANCES} ${AUTO} ${IMAGE_NAME}
+    ice group create --name ${MY_GROUP_NAME} ${BIND_PARMS} ${PUBLISH_PORT} ${MEMORY} ${OPTIONAL_ARGS} --desired ${DESIRED_INSTANCES} ${AUTO} ${INJECTED_ENV[*]} ${IMAGE_NAME}
     local RESULT=$?
     if [ $RESULT -ne 0 ]; then
         echo -e "${red}Failed to deploy ${MY_GROUP_NAME} using ${IMAGE_NAME}${no_color}"


### PR DESCRIPTION
Allow deploy pipeline scripts to export variables of the form:

```
export INJECT_varname=somevalue
export INJECT_some_other_var=other_value
```

and have them added to `ice run` and `ice group create` command line options so that specific environment contents can be passed to Docker containers.

The `INJECT_` prefix is removed and the resultant variable name with its value is passed as `--env var=val` to the appropriate `ice` command.
