### PR TITLE
Create a default route if not specified

### DIFF
--- a/deploycontainer.sh
+++ b/deploycontainer.sh
@@ -511,6 +511,8 @@ if [ -z "$CONCURRENT_VERSIONS" ];then
 fi
 
 log_and_echo "$LABEL" "Deploying using ${DEPLOY_TYPE} strategy, for ${CONTAINER_NAME}, deploy number ${BUILD_NUMBER}"
+${EXT_DIR}/utilities/sendMessage.sh -l info -m "New ${DEPLOY_TYPE} container deployment for ${CONTAINER_NAME} requested"
+
 if [ "${DEPLOY_TYPE}" == "red_black" ]; then
     deploy_red_black
 elif [ "${DEPLOY_TYPE}" == "clean" ]; then

--- a/deploycontainer.sh
+++ b/deploycontainer.sh
@@ -303,6 +303,7 @@ deploy_simple () {
     local RESULT=$?
     if [ $RESULT -ne 0 ]; then
         log_and_echo "$ERROR" "Error encountered with simple build strategy for ${CONTAINER_NAME}_${BUILD_NUMBER}"
+        ${EXT_DIR}/utilities/sendMessage.sh -l bad -m "Failed deployment"
         exit $RESULT
     fi
 }
@@ -316,6 +317,7 @@ deploy_red_black () {
     deploy_container ${MY_CONTAINER_NAME}
     local RESULT=$?
     if [ $RESULT -ne 0 ]; then
+        ${EXT_DIR}/utilities/sendMessage.sh -l bad -m "Failed deployment of ${MY_CONTAINER_NAME}"
         exit $RESULT
     fi
 
@@ -323,6 +325,7 @@ deploy_red_black () {
     clean
     RESULT=$?
     if [ $RESULT -ne 0 ]; then
+        ${EXT_DIR}/utilities/sendMessage.sh -l bad -m "Failed to cleanup previous deployments after deployment of ${MY_CONTAINER_NAME}"
         exit $RESULT
     fi
     # if we alredy discoved the floating IP in clean(), then we assign it to FLOATING_IP.
@@ -346,6 +349,7 @@ deploy_red_black () {
             if [ -z "${FLOATING_IP}" ];then
                 log_and_echo "$ERROR" "Could not request a new, or reuse an existing IP address "
                 dump_info
+                ${EXT_DIR}/utilities/sendMessage.sh -l bad -m "Failed deployment of ${MY_CONTAINER_NAME}.  Unable to allocate IP address."
                 exit 1
             else
                 log_and_echo "Assigning existing IP address $FLOATING_IP"
@@ -363,6 +367,7 @@ deploy_red_black () {
             log_and_echo "Unsetting TEST_URL"
             export TEST_URL=""
             dump_info
+            ${EXT_DIR}/utilities/sendMessage.sh -l bad -m "Failed binding of IP address to ${MY_CONTAINER_NAME}"
             exit 1
         fi
     fi
@@ -517,4 +522,5 @@ else
     deploy_red_black
 fi
 dump_info
+${EXT_DIR}/utilities/sendMessage.sh -l good -m "Sucessful deployment of ${CONTAINER_NAME}"
 exit 0

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -515,7 +515,7 @@ clean() {
 #   simple: simply deploy a container and set the inventory
 #   red_black: deploy new container, assign floating IP address, keep original container
 log_and_echo "$LABEL" "Deploying using ${DEPLOY_TYPE} strategy, for ${CONTAINER_NAME}, deploy number ${BUILD_NUMBER}"
-${EXT_DIR}/utilities/sendMessage.sh -l info -m "New ${DEPLOY_TYPE} deployment for ${CONTAINER_NAME} requested"
+${EXT_DIR}/utilities/sendMessage.sh -l info -m "New ${DEPLOY_TYPE} copntainer group deployment for ${CONTAINER_NAME} requested"
 
 
 check_num='^[0-9]+$'
@@ -632,5 +632,5 @@ else
 fi
 
 dump_info
-${EXT_DIR}/utilities/sendMessage.sh -l good -m "Successful ${DEPLOY_TYPE} deployment of ${CONTAINER_NAME}"
+${EXT_DIR}/utilities/sendMessage.sh -l good -m "Successful ${DEPLOY_TYPE} container group deployment of ${CONTAINER_NAME}"
 exit 0

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -53,6 +53,10 @@ print_create_fail_msg () {
     log_and_echo ""
 }
 
+debugme() {
+  [[ $DEBUG = 1 ]] && "$@" || :
+}
+
 dump_info () {
     log_and_echo "$LABEL" "Container Information: "
     log_and_echo "$LABEL" "Information about this organization and space:"
@@ -77,15 +81,29 @@ dump_info () {
     fi
 
     log_and_echo "$LABEL" "Groups: "
-    log_and_echo `ice group list 2> /dev/null`
+    ice group list > mylog.log 2>&1 
+    debugme cat mylog.log
+    log_and_echo "$DEBUGGING" `cat mylog.log`
+
     log_and_echo "$LABEL" "Routes: "
-    log_and_echo `cf routes`
+    cf routes > mylog.log 2>&1 
+    debugme cat mylog.log
+    log_and_echo "$DEBUGGING" `cat mylog.log`
+
     log_and_echo "$LABEL" "Running Containers: "
-    log_and_echo `ice ps 2> /dev/null`
-    log_and_echo "$LABEL" "Floating IP addresses"
-    log_and_echo `ice ip list 2> /dev/null`
+    ice ps > mylog.log 2>&1 
+    debugme cat mylog.log
+    log_and_echo "$DEBUGGING" `cat mylog.log`
+
+    log_and_echo "$LABEL" "IP addresses"
+    ice ip list > mylog.log 2>&1 
+    debugme cat mylog.log
+    log_and_echo "$DEBUGGING" `cat mylog.log`
+
     log_and_echo "$LABEL" "Images:"
-    log_and_echo `ice images 2> /dev/null`
+    ice images > mylog.log 2>&1 
+    debugme cat mylog.log
+    log_and_echo "$DEBUGGING" `cat mylog.log`
 
     return 0
 }

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -85,12 +85,7 @@ dump_info () {
     log_and_echo "$LABEL" "Floating IP addresses"
     log_and_echo `ice ip list 2> /dev/null`
     log_and_echo "$LABEL" "Images:"
-    ice images > inspect.log 2>&1 
-    IMAGE_ARRAY=$(cat inspect.log)
-    for image in ${IMAGE_ARRAY[@]}
-    do
-        log_and_echo "${image}"
-    done 
+    log_and_echo `ice images 2> /dev/null`
 
     return 0
 }
@@ -273,7 +268,7 @@ map_url_route_to_container_group (){
                     log_and_echo "${green}Request to map route ('${HOSTNAME}.${DOMAIN}') to container group '${GROUP_NAME}' completed successfully.${no_color}"
                     break
                 else
-                    log_and_echo "Requested route ('${HOSTNAME}.${DOMAIN}') did not return successfully (Response code = ${RESPONSE}). Sleep 10 sec and try to check again."
+                    log_and_echo "${WARN}" "Requested route ('${HOSTNAME}.${DOMAIN}') did not return successfully (Response code = ${RESPONSE}). Sleep 10 sec and try to check again."
                     sleep 10
                 fi
             done

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -541,7 +541,7 @@ fi
 # generate a route if one does not exist 
 if [ -z "${ROUTE_DOMAIN}" ]; then 
     log_and_echo "ROUTE_DOMAIN not set, will default to existing route domain.  ROUTE_DOMAIN can be set as an environment property on the stage"
-    export ROUTE_DOMAIN==$(cf routes | tail -1 | awk '{print $2}')
+    export ROUTE_DOMAIN=$(cf routes | tail -1 | awk '{print $2}')
     if [ -z "${ROUTE_DOMAIN}" ]; then 
         export ROUTE_DOMAIN=$(cf domains | grep -E '[a-z0-9]\.' | tail -1 | awk '{print $1}') 
         log_and_echo "No existing domains found, using organization domain (${ROUTE_DOMAIN})"  

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -243,7 +243,8 @@ map_url_route_to_container_group (){
     # This check is not very useful ... it resturns 0 all the time and just indicates if the route is already created 
     cf check-route ${HOSTNAME} ${DOMAIN} | grep "does exist"
     local ROUTE_EXISTS=$?
-    if [ ${ROUTE_EXISTS} -ne 0 ]; then 
+    if [ ${ROUTE_EXISTS} -ne 0 ]; then
+        # make sure we are using CF from our extension so that we can always call target.   
         local MYSPACE=$(${EXT_DIR}/cf target | grep Space | awk '{print $2}' | sed 's/ //g')
         log_and_echo "Route does not exist, attempting to create for ${HOSTNAME} ${DOMAIN} in ${MYSPACE}"
         cf create-route ${MYSPACE} ${DOMAIN} -n ${HOSTNAME}
@@ -542,7 +543,7 @@ fi
 # generate a route if one does not exist 
 if [ -z "${ROUTE_DOMAIN}" ]; then 
     log_and_echo "ROUTE_DOMAIN not set, will attempt to find existing route domain to use. ${label_color} ROUTE_DOMAIN can be set as an environment property on the stage${no_color}"
-    export ROUTE_DOMAIN=$(cf routes | tail -1 | awk '{print $2}')
+    export ROUTE_DOMAIN=$(cf routes | tail -1 | grep -E '[a-z0-9]\.' | awk '{print $2}')
     if [ -z "${ROUTE_DOMAIN}" ]; then 
         export ROUTE_DOMAIN=$(cf domains | grep -E '[a-z0-9]\.' | tail -1 | awk '{print $1}') 
         log_and_echo "No existing domains found, using organization domain (${ROUTE_DOMAIN})"  

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -253,12 +253,12 @@ map_url_route_to_container_group (){
     local ROUTE_EXISTS=$?
     if [ ${ROUTE_EXISTS} -ne 0 ]; then
         # make sure we are using CF from our extension so that we can always call target.   
-        local MYSPACE=$(${EXT_DIR}/cf target | grep Space | awk '{print $3}' | sed 's/ //g')
+        local MYSPACE=$(${EXT_DIR}/cf target | grep Space | awk '{print $2}' | sed 's/ //g')
         log_and_echo "Route does not exist, attempting to create for ${HOSTNAME} ${DOMAIN} in ${MYSPACE}"
         cf create-route ${MYSPACE} ${DOMAIN} -n ${HOSTNAME}
         RESULT=$?
-        log_and_echo "$WARN_LEVEL" "The created route will be reused for this stage, and will persist as an organizational route even if this container group is removed"
-        log_and_echo "$WARN_LEVEL" "If you wish to remove this route use the following command: cf delete-route ROUTE_DOMAIN -n ROUTE_HOSTNAME"
+        log_and_echo "$WARN" "The created route will be reused for this stage, and will persist as an organizational route even if this container group is removed"
+        log_and_echo "$WARN" "If you wish to remove this route use the following command: cf delete-route ROUTE_DOMAIN -n ROUTE_HOSTNAME"
     else 
         log_and_echo "Route already created for ${HOSTNAME} ${DOMAIN}"
         local RESULT=0
@@ -547,7 +547,7 @@ if [ -z "${ROUTE_HOSTNAME}" ]; then
     MY_STAGE_NAME=$(echo $IDS_STAGE_NAME | sed 's/ //g')
     MY_STAGE_NAME=$(echo $MY_STAGE_NAME | sed 's/\./-/g')
     export ROUTE_HOSTNAME=${GEN_NAME}-${MY_STAGE_NAME}
-    log_and_echo "$WARN_LEVEL" "Generated ROUTE_HOSTNAME is ${ROUTE_HOSTNAME}."  
+    log_and_echo "$WARN" "Generated ROUTE_HOSTNAME is ${ROUTE_HOSTNAME}."  
  fi 
 
 # generate a route if one does not exist 

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -532,8 +532,8 @@ fi
 # if the user has not defined a Route then create one
 if [ -z "${ROUTE_HOSTNAME}" ]; then
     log_and_echo "ROUTE_HOSTNAME not set.  One will be generated, or ROUTE_HOSTNAME for an existing route can be set as an environment property on the stage"
-    local GEN_NAME=$(echo $IDS_PROJECT_NAME | sed 's/ | /-/g')
-    local MY_STAGE_NAME=$(echo $IDS_STAGE_NAME | sed 's/ //g')
+    GEN_NAME=$(echo $IDS_PROJECT_NAME | sed 's/ | /-/g')
+    MY_STAGE_NAME=$(echo $IDS_STAGE_NAME | sed 's/ //g')
     MY_STAGE_NAME=$(echo $MY_STAGE_NAME | sed 's/\./-/g')
     export ROUTE_HOSTNAME=${GEN_NAME}-${MY_STAGE_NAME}
 fi 

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -82,27 +82,27 @@ dump_info () {
 
     log_and_echo "$LABEL" "Groups: "
     ice group list > mylog.log 2>&1 
-    debugme cat mylog.log
+    cat mylog.log
     log_and_echo "$DEBUGGING" `cat mylog.log`
 
     log_and_echo "$LABEL" "Routes: "
     cf routes > mylog.log 2>&1 
-    debugme cat mylog.log
+    cat mylog.log
     log_and_echo "$DEBUGGING" `cat mylog.log`
 
     log_and_echo "$LABEL" "Running Containers: "
     ice ps > mylog.log 2>&1 
-    debugme cat mylog.log
+    cat mylog.log
     log_and_echo "$DEBUGGING" `cat mylog.log`
 
     log_and_echo "$LABEL" "IP addresses"
     ice ip list > mylog.log 2>&1 
-    debugme cat mylog.log
+    cat mylog.log
     log_and_echo "$DEBUGGING" `cat mylog.log`
 
     log_and_echo "$LABEL" "Images:"
     ice images > mylog.log 2>&1 
-    debugme cat mylog.log
+    cat mylog.log
     log_and_echo "$DEBUGGING" `cat mylog.log`
 
     return 0

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -531,16 +531,17 @@ fi
 
 # if the user has not defined a Route then create one
 if [ -z "${ROUTE_HOSTNAME}" ]; then
-    log_and_echo "ROUTE_HOSTNAME not set.  One will be generated, or ROUTE_HOSTNAME for an existing route can be set as an environment property on the stage"
+    log_and_echo "ROUTE_HOSTNAME not set.  One will be generated.  ${label_color}ROUTE_HOSTNAME can be set as an environment property on the stage${no_color}"
     GEN_NAME=$(echo $IDS_PROJECT_NAME | sed 's/ | /-/g')
     MY_STAGE_NAME=$(echo $IDS_STAGE_NAME | sed 's/ //g')
     MY_STAGE_NAME=$(echo $MY_STAGE_NAME | sed 's/\./-/g')
     export ROUTE_HOSTNAME=${GEN_NAME}-${MY_STAGE_NAME}
+    log_and_echo "Generated ROUTE_HOSTNAME is ${ROUTE_HOSTNAME}."  
 fi 
 
 # generate a route if one does not exist 
 if [ -z "${ROUTE_DOMAIN}" ]; then 
-    log_and_echo "ROUTE_DOMAIN not set, will default to existing route domain.  ROUTE_DOMAIN can be set as an environment property on the stage"
+    log_and_echo "ROUTE_DOMAIN not set, will attempt to find existing route domain to use. ${label_color} ROUTE_DOMAIN can be set as an environment property on the stage${no_color}"
     export ROUTE_DOMAIN=$(cf routes | tail -1 | awk '{print $2}')
     if [ -z "${ROUTE_DOMAIN}" ]; then 
         export ROUTE_DOMAIN=$(cf domains | grep -E '[a-z0-9]\.' | tail -1 | awk '{print $1}') 

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -76,26 +76,21 @@ dump_info () {
         fi
     fi
 
-#    export IP_LIMIT=$(echo "$ICEINFO" | grep "Floating IPs limit" | awk '{print $5}')
-#    export IP_COUNT=$(echo "$ICEINFO" | grep "Floating IPs usage" | awk '{print $5}')
-#
-#    local AVAILABLE="$(echo "$IP_LIMIT - $IP_COUNT" | bc)"
-#    if [ ${AVAILABLE} -le 0 ]; then
-#        echo -e "${red}You have reached the default limit for the number of available public IP addresses${no_color}"
-#    else
-#        echo -e "${label_color}You have ${AVAILABLE} public IP addresses remaining${no_color}"
-#    fi
-
-    log_and_echo "Groups: "
+    log_and_echo "$LABEL" "Groups: "
     log_and_echo `ice group list 2> /dev/null`
-    log_and_echo "Routes: "
+    log_and_echo "$LABEL" "Routes: "
     log_and_echo `cf routes`
-    log_and_echo "Running Containers: "
+    log_and_echo "$LABEL" "Running Containers: "
     log_and_echo `ice ps 2> /dev/null`
-    log_and_echo "Floating IP addresses"
+    log_and_echo "$LABEL" "Floating IP addresses"
     log_and_echo `ice ip list 2> /dev/null`
-    log_and_echo "Images:"
-    log_and_echo `ice images`
+    log_and_echo "$LABEL" "Images:"
+    ice images > inspect.log 2>&1 
+    IMAGE_ARRAY=$(cat inspect.log)
+    for image in ${IMAGE_ARRAY[@]}
+    do
+        log_and_echo "${image}"
+    done 
 
     return 0
 }
@@ -275,10 +270,10 @@ map_url_route_to_container_group (){
                 let COUNTER=COUNTER+1
                 RESPONSE=$(curl --write-out %{http_code} --silent --output /dev/null ${HOSTNAME}.${DOMAIN})
                 if [ "$RESPONSE" -eq 200 ]; then
-                    log_and_echo "${green}Map requested route ('${HOSTNAME}.${DOMAIN}') to container group '${GROUP_NAME}' completed.${no_color}"
+                    log_and_echo "${green}Request to map route ('${HOSTNAME}.${DOMAIN}') to container group '${GROUP_NAME}' completed successfully.${no_color}"
                     break
                 else
-                    log_and_echo "Requested route ('${HOSTNAME}.${DOMAIN}') does not exist (Response code = ${RESPONSE}). Sleep 10 sec and try to check again."
+                    log_and_echo "Requested route ('${HOSTNAME}.${DOMAIN}') did not return successfully (Response code = ${RESPONSE}). Sleep 10 sec and try to check again."
                     sleep 10
                 fi
             done

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -298,7 +298,7 @@ map_url_route_to_container_group (){
         fi
     else
         log_and_echo "$ERROR" "No route mapped to Container Group"
-        return 0
+        return 1
     fi
     return 0
 }
@@ -364,7 +364,7 @@ deploy_group() {
             map_url_route_to_container_group ${MY_GROUP_NAME} ${ROUTE_HOSTNAME} ${ROUTE_DOMAIN}
             RET=$?
             if [ $RET -eq 0 ]; then
-                log_and_echo "${green}Successfully mapped '$ROUTE_HOSTNAME.$ROUTE_DOMAIN' URL to container group '$MY_GROUP_NAME'.${no_color}"
+                log_and_echo "Successfully mapped '$ROUTE_HOSTNAME.$ROUTE_DOMAIN' URL to container group '$MY_GROUP_NAME'."
             else
                 if [ "${DEBUG}x" != "1x" ]; then
                     log_and_echo "$WARN" "You can check the route status with 'curl ${ROUTE_HOSTNAME}.${ROUTE_DOMAIN}' command after the deploy completed."

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -244,10 +244,9 @@ map_url_route_to_container_group (){
     cf check-route ${HOSTNAME} ${DOMAIN} | grep "does exist"
     local ROUTE_EXISTS=$?
     if [ ${ROUTE_EXISTS} -ne 0 ]; then 
-        local MYSPACE=$(${EXT_DIR}/cf target | grep Space | awk '{print $2}')
+        local MYSPACE=$(${EXT_DIR}/cf target | grep Space | awk '{print $2}' | sed 's/ //g')
         log_and_echo "Route does not exist, attempting to create for ${HOSTNAME} ${DOMAIN} in ${MYSPACE}"
         cf create-route ${MYSPACE} ${DOMAIN} -n ${HOSTNAME}
-        debugme cf routes
         RESULT=$?
     else 
         log_and_echo "Route already created for ${HOSTNAME} ${DOMAIN}"

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -325,6 +325,7 @@ deploy_group() {
     local FOUND=$?
     if [ ${FOUND} -eq 0 ]; then
         log_and_echo "$ERROR" "${MY_GROUP_NAME} already exists. Please delete it or run group deployment again."
+        ${EXT_DIR}/utilities/sendMessage.sh -l bad -m "Deployment of ${MY_GROUP_NAME} failed as the group already exists"
         exit 1
     fi
 
@@ -405,6 +406,7 @@ deploy_simple () {
     local RESULT=$?
     if [ $RESULT -ne 0 ]; then
         log_and_echo "$ERROR" "Error encountered with simple build strategy for ${CONTAINER_NAME}_${BUILD_NUMBER}"
+        ${EXT_DIR}/utilities/sendMessage.sh -l bad -m "Failed deployment"
         exit $RESULT
     fi
 }
@@ -416,6 +418,7 @@ deploy_red_black () {
     deploy_group ${MY_GROUP_NAME}
     local RESULT=$?
     if [ $RESULT -ne 0 ]; then
+        ${EXT_DIR}/utilities/sendMessage.sh -l bad -m "Deployment of ${MY_GROUP_NAME} failed"
         exit $RESULT
     fi
 
@@ -423,6 +426,7 @@ deploy_red_black () {
         clean
         RESULT=$?
         if [ $RESULT -ne 0 ]; then
+            ${EXT_DIR}/utilities/sendMessage.sh -l bad -m "Failed to cleanup previous groups after deployment of group ${MY_GROUP_NAME}"
             exit $RESULT
         fi
     else
@@ -511,6 +515,8 @@ clean() {
 #   simple: simply deploy a container and set the inventory
 #   red_black: deploy new container, assign floating IP address, keep original container
 log_and_echo "$LABEL" "Deploying using ${DEPLOY_TYPE} strategy, for ${CONTAINER_NAME}, deploy number ${BUILD_NUMBER}"
+${EXT_DIR}/utilities/sendMessage.sh -l info -m "New ${DEPLOY_TYPE} deployment for ${CONTAINER_NAME} requested"
+
 
 check_num='^[0-9]+$'
 if [ -z "$DESIRED_INSTANCES" ]; then
@@ -626,4 +632,5 @@ else
 fi
 
 dump_info
+${EXT_DIR}/utilities/sendMessage.sh -l good -m "Successful ${DEPLOY_TYPE} deployment of ${CONTAINER_NAME}"
 exit 0

--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -243,7 +243,7 @@ map_url_route_to_container_group (){
     # This check is not very useful ... it resturns 0 all the time and just indicates if the route is already created 
     cf check-route ${HOSTNAME} ${DOMAIN} | grep "does exist"
     local ROUTE_EXISTS=$?
-    if [ ROUTE_EXISTS -ne 0 ]; then 
+    if [ ${ROUTE_EXISTS} -ne 0 ]; then 
         local MYSPACE=$(${EXT_DIR}/cf target | grep Space | awk '{print $2}')
         log_and_echo "Route does not exist, attempting to create for ${HOSTNAME} ${DOMAIN} in ${MYSPACE}"
         cf create-route ${MYSPACE} ${DOMAIN} -n ${HOSTNAME}
@@ -545,12 +545,11 @@ else
 fi
 
 if [ -z "$ROUTE_HOSTNAME" ]; then
-    log_and_echo "$WARN" "ROUTE_HOSTNAME not set.  Please set the desired or existing route hostname as an environment property on the stage."
+    log_and_echo "ROUTE_HOSTNAME not set.  One will be generated, or ROUTE_HOSTNAME for an existing route can be set as an environment property on the stage"
 fi
 
 if [ -z "$ROUTE_DOMAIN" ]; then
-    log_and_echo "$WARN" "ROUTE_DOMAIN not set, defaulting to mybluemix.net"
-    export ROUTE_DOMAIN="mybluemix.net"
+    log_and_echo "ROUTE_DOMAIN not set, will default to existing route domain.  ROUTE_DOMAIN can be set as an environment property on the stage"
 fi
 
 if [ -z "$CONCURRENT_VERSIONS" ];then


### PR DESCRIPTION
Using the container group name as the default route name was too fragile to ensure that the route did not already exist. 

Fell back to simply generating a route for ROUTE_HOSTNAME and ROUTE_DOMAIN.  This uses the IDS projectname-stagename. 
