### PR TITLE
WI 78265 - don't fail cleanup for bad unmap

### DIFF
--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -325,8 +325,6 @@ clean() {
             RESULT=$?
             if [ $RESULT -ne 0 ]; then
                 log_and_echo "$WARN" "'ice route unmap --hostname $ROUTE_HOSTNAME --domain $ROUTE_DOMAIN ${groupName}' command failed with return code ${RESULT}"
-                log_and_echo "$WARN" "Cleaning up previous deployments is not completed"
-                return 0
             fi
             sleep 2
             log_and_echo "delete inventory: ${groupName}"


### PR DESCRIPTION
Per this defect - shouldn't abort out of a cleanup if unmap fails - continue and try delete the group anyway (which will also do an unmap), otherwise we end up with extra copies of old groups filling up the space.
