### PR TITLE
switch ver check to string comp not int comp

### DIFF
--- a/deploy_utilities.sh
+++ b/deploy_utilities.sh
@@ -530,7 +530,7 @@ check_image() {
             else
                 for VER in ${VERSION_LIST[@]} 
                 do 
-                    if [ $VER -eq $IMAGE_VERSION ]; then 
+                    if [ "$VER" == "$IMAGE_VERSION" ]; then 
                         return 0
                     fi
                 done  


### PR DESCRIPTION
tag is a string, needs to work against non-integers as well.  does not apply to ice path, since that uses a single grep
