### PR TITLE
Fix to check container group create status

### DIFF
--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -42,7 +42,7 @@ wait_for_group (){
     local STATUS="unknown"
     while [[ ( $COUNTER -lt 180 ) ]]; do
         let COUNTER=COUNTER+1
-        STATUS=$($IC_COMMAND group inspect $WAITING_FOR | grep "Status" | awk '{print $2}' | sed 's/,//g')
+        STATUS=$($IC_COMMAND group inspect $WAITING_FOR | grep -w "Status" | awk '{print $2}' | sed 's/,//g')
         if [ -z "${STATUS}" ] && [ "$USE_ICE_CLI" = "1" ]; then
             # get continer status: attribute="Name", value=${WAITING_FOR}, search_attribute="Status"
             get_container_group_value_for_given_attribute "Name" ${WAITING_FOR} "Status"


### PR DESCRIPTION
Loop goes through all iterations and eventually fails the container group create job.

grep in L45 returns a string that hits two instances of string "Status" from group inspect. So, even though 'CREATE_COMPLETE' happens, the condition always fails. grepping for word returns just the Status string.
