### PR TITLE
fix for group route fails with space in space name

### DIFF
--- a/deploygroup.sh
+++ b/deploygroup.sh
@@ -97,9 +97,9 @@ map_url_route_to_container_group (){
     local ROUTE_EXISTS=$?
     if [ ${ROUTE_EXISTS} -ne 0 ]; then
         # make sure we are using CF from our extension so that we can always call target.   
-        local MYSPACE=$(${EXT_DIR}/cf target | grep Space | awk '{print $2}' | sed 's/ //g')
+        local MYSPACE=$(${EXT_DIR}/cf target | sed -n -e 's/^,*Space://p' | sed -e 's/^[[:space:]]*//' | sed -e 's/[[:space:]]*$//')
         log_and_echo "Route does not exist, attempting to create for ${HOSTNAME} ${DOMAIN} in ${MYSPACE}"
-        cf create-route ${MYSPACE} ${DOMAIN} -n ${HOSTNAME}
+        cf create-route "${MYSPACE}" ${DOMAIN} -n ${HOSTNAME}
         RESULT=$?
         log_and_echo "$WARN" "The created route will be reused for this stage, and will persist as an organizational route even if this container group is removed"
         log_and_echo "$WARN" "If you wish to remove this route use the following command: cf delete-route ROUTE_DOMAIN -n ROUTE_HOSTNAME"


### PR DESCRIPTION
group create fails if the route needs to be created, and the owning space has a space in the name.  adjusted space detection and usage to handle this. 