### PR TITLE
adopt PIPELINE_API_URL for V2 container extension

### DIFF
--- a/deploy_utilities.sh
+++ b/deploy_utilities.sh
@@ -465,6 +465,7 @@ update_inventory(){
     # find other inventory information
     log_and_echo "$LABEL" "Updating inventory with $TYPE of $NAME "
     local IDS_INV_URL="${IDS_URL%/}"
+    local IDS_PIPELINE_API_URL=$PIPELINE_API_URL
     local IDS_REQUEST=$TASK_ID
     local IDS_DEPLOYER=${JOB_NAME##*/}
     if [ ! -z "$COPYARTIFACT_BUILD_NUMBER" ] ; then
@@ -493,8 +494,12 @@ update_inventory(){
     IDS_RESOURCE=$CF_SPACE_ID
     if [ -z "$IDS_RESOURCE" ]; then
         log_and_echo "$ERROR" "Could not find CF SPACE in environment, using production space id"
+    elif [ ! -z "$IDS_PIPELINE_API_URL"]; then
+        # call IBM DevOps Service V2 Inventory CLI to update the entry for this deployment
+        log_and_echo "bash ids-inv -a ${ACTION} -d $IDS_DEPLOYER -q $IDS_REQUEST -r $IDS_RESOURCE -s $ID -t ${TYPE} -p $IDS_PIPELINE_API_URL -v $IDS_VERSION"
+        bash ids-inv -a ${ACTION} -d $IDS_DEPLOYER -q $IDS_REQUEST -r $IDS_RESOURCE -s $ID -t ${TYPE} -p $IDS_PIPELINE_API_URL -v $IDS_VERSION
     else
-        # call IBM DevOps Service Inventory CLI to update the entry for this deployment
+        # call IBM DevOps Service V1 Inventory CLI to update the entry for this deployment
         log_and_echo "bash ids-inv -a ${ACTION} -d $IDS_DEPLOYER -q $IDS_REQUEST -r $IDS_RESOURCE -s $ID -t ${TYPE} -u $IDS_INV_URL -v $IDS_VERSION"
         bash ids-inv -a ${ACTION} -d $IDS_DEPLOYER -q $IDS_REQUEST -r $IDS_RESOURCE -s $ID -t ${TYPE} -u $IDS_INV_URL -v $IDS_VERSION
     fi


### PR DESCRIPTION
In pipeline V2 there is a new REST endpoint for making inventory update requests.  The old endpoint still works in pipeline V1 but no longer works in V2 since a CSRF check was recently added in the pipeline UI service.

I updated the ids-inv script in the pipeline worker image to support a new command line option `-p PIPELINE_API_URL` which will take precedence over the `-u IDS_URL` option.   This pull request is for updating deploy_utilities.sh to adopt this new `-p` command line option for pipeline V2 while still using the `-u` option for pipeline V1.